### PR TITLE
fix: 'asdf plugin add' was not working when the version was included in the command

### DIFF
--- a/go/.tool-versions
+++ b/go/.tool-versions
@@ -1,3 +1,3 @@
+direnv 2.32.1
 golang 1.18.3
 golangci-lint 1.46.1
-

--- a/go/script/asdf_bootstrap.sh
+++ b/go/script/asdf_bootstrap.sh
@@ -54,7 +54,7 @@ asdf_install_check() {
 		fi
 		if [ "$OS" == "Darwin" ]; then
 			asdf_path="$(brew --prefix asdf)/libexec/asdf.sh"
-			echo -e "\n. ${asdf_path}" >> ${ZDOTDIR:-~}/.zshrc
+			echo "\n. ${asdf_path}" >> ${ZDOTDIR:-~}/.zshrc
 			. ${asdf_path}
 		fi
 	else
@@ -68,10 +68,12 @@ direnv_install() {
 }
 
 install_tool_plugins() {
-	while IFS="\n" read -r dependency 
+	while IFS="\n" read -r plugin
 	do
-		if [ "$dependency" != "" ]; then
-			asdf plugin add $dependency
+		plugin=$(echo $plugin | cut -d' ' -f1)
+		if [ "$plugin" != "" ]; then
+			echo "adding plugin $plugin"
+			asdf plugin add $plugin
 		fi
 	done < .tool-versions
 }
@@ -96,6 +98,3 @@ direnv reload
 echo "We need to run direnv allow . once to make this configuration valid."
 interactive_exec "direnv allow ."
 echo "Done..."
-
-
-


### PR DESCRIPTION
A few things that weren't working on my mac:
- adding the asdf path to `.zshrc` somehow added an additional `-e` before the new line
- `asdf plugin add __` was failing for me because it was including the version number in each of the plugins, e.g. `asdf plugin add golang 1.18.3` which didn't work

Also I had to reload my shell `exec $SHELL` or `source ~/.zshrc` or exit the terminal and open a new session in order to get access to `direnv` at all.

I added `direnv` to `.tool-versions` as `direnv reload`  complained about the following:
```
No version is set for command direnv
Consider adding one of the following versions in your config file at /Users/dahliabock/projects/oss/asdf-demo/go/.tool-versions
direnv 2.32.1
```